### PR TITLE
Stop passing --dev flag to A/B Street

### DIFF
--- a/js/actdev.js
+++ b/js/actdev.js
@@ -169,7 +169,7 @@ var actdev = (function ($) {
 			apiKey: false,
 			popupHtml: ''
 				+ '<h3>Study area: {properties.site_name}</h3>'
-				+ '<p id="simulation"><a target="_blank" href="/abstreet/?--dev&--actdev={properties.site_name}">Open travel simulation <br />in A/B Street</a></p>',
+				+ '<p id="simulation"><a target="_blank" href="/abstreet/?--actdev={properties.site_name}">Open travel simulation <br />in A/B Street</a></p>',
 			style: {
 				Polygon: {
 					"fill-outline-color": "red",


### PR DESCRIPTION
As of https://github.com/cyipt/actdev/releases/tag/0.1.6, the `--actdev=$SITE` flag is all that's needed to customize the UI for integration with actdev.

Still TODO: pass the current slippy map's view as `--cam`